### PR TITLE
fix: Use the default font

### DIFF
--- a/Dark+.toml
+++ b/Dark+.toml
@@ -115,7 +115,7 @@ variable = "#9cdcfe"
 "terminal.yellow" = "#e5e510"
 
 [ui]
-font-family = "system"
+font-family = ""
 font-size = 13
 header-height = 35
 status-height = 25

--- a/Light+.toml
+++ b/Light+.toml
@@ -115,7 +115,7 @@ variable = "#001080"
 "terminal.yellow" = "#e5e510"
 
 [ui]
-font-family = "system-ui"
+font-family = ""
 font-size = 12
 header-height = 35
 status-height = 25


### PR DESCRIPTION
I don't know what "system" gets mapped to but it looks absolutely terrible. Let's default to what Lapce uses, which is at least readable